### PR TITLE
Fixes #57 Changes to ResourceDao and ResourceRepository

### DIFF
--- a/app/src/main/java/com/tiptopgoodstudio/androidresources/ResourceRepository.java
+++ b/app/src/main/java/com/tiptopgoodstudio/androidresources/ResourceRepository.java
@@ -1,10 +1,9 @@
 package com.tiptopgoodstudio.androidresources;
 
-
 import android.app.Application;
 import android.arch.lifecycle.LiveData;
+import android.arch.lifecycle.MutableLiveData;
 import android.os.AsyncTask;
-
 
 import com.tiptopgoodstudio.androidresources.db.AppDatabase;
 import com.tiptopgoodstudio.androidresources.db.dao.ResourceDao;
@@ -17,7 +16,11 @@ public class ResourceRepository {
     private ResourceDao mResourceDao;
     private LiveData<List<Resource>> mAllResources;
 
-
+    /**
+     * Constructor
+     *
+     * @param application
+     */
     public ResourceRepository(Application application) {
 
         AppDatabase db = AppDatabase.getDatabase(application);
@@ -25,71 +28,58 @@ public class ResourceRepository {
         mAllResources = mResourceDao.getResources();
     }
 
-LiveData<List<Resource>> getResouces()
-{
-    return mAllResources;
-}
-public void insertResource(Resource resource){
-
+    /**
+     * method returns all resource records in Room db resource_table in LiveData wrapper
+     *
+     * @return LiveData<List   <   Resource>>
+     */
     public LiveData<List<Resource>> getAllResouces() {
         return mAllResources;
     }
 
-    public LiveData<List<Resource>> getTopicResources(String topic) {
+    /**
+     * method returns all resource records which match topic parameter from
+     * Room db resource_table MutableLiveData wrapper
+     *
+     * @param topic
+     * @return MutableLiveData<List   <   Resource>>
+     */
+    public MutableLiveData<List<Resource>> getTopicResources(String topic) {
         return mResourceDao.getTopicResources(topic);
     }
 
-    public Resource getResourceById(int id) {
-        return mResourceDao.getResourceById(id);
+    /**
+     * delete all records in Room db resource_table
+     */
+    private void deleteAllRecords() {
+        mResourceDao.deleteAll();
     }
 
-    public void insert(Resource resource) {
-
-        new InsertAsyncTask(mResourceDao).execute(resource);
+    /**
+     * Method to insert multiple resource objects into Room db resource_table
+     * Calls InssertResourceAsyncTask so as to perform work off main thread
+     *
+     * @param resources
+     */
+    private void insertResources(Resource... resources) {
+        new InsertResourceAsyncTask(mResourceDao).execute(resources);
     }
 
-    private static class InsertAsyncTask extends AsyncTask<Resource, Void, Void> {
-        private ResourceDao mAsyncTaskDao;
+    /**
+     * Inner AsyncTask subclass to insert Resource objects into Room db resource_table
+     */
+    private static class InsertResourceAsyncTask extends AsyncTask<Resource, Void, Void> {
+        private ResourceDao taskDao;
 
-        InsertAsyncTask(ResourceDao dao) {
-            mAsyncTaskDao = dao;
+        InsertResourceAsyncTask(ResourceDao dao) {
+            this.taskDao = dao;
         }
 
         @Override
-        protected Void doInBackground(final Resource... resources) {
-
-            mAsyncTaskDao.insertResource(resources[0]);
+        protected Void doInBackground(Resource... resources) {
+            taskDao.insertResources(resources);
             return null;
-
-
         }
     }
 
-    public String getResourceFormat(int id) {
-        return mResourceDao.getResourceFormat(id);
-    }
-
-    public void updateResource(Resource resource) {
-        new UpdateAsyncTask(mResourceDao).execute(resource);
-    }
-
-
-    private static class UpdateAsyncTask extends AsyncTask<Resource, Void, Void> {
-        private ResourceDao mAsyncTaskDao;
-
-        UpdateAsyncTask(ResourceDao dao) {
-            mAsyncTaskDao = dao;
-        }
-
-        @Override
-        protected Void doInBackground(final Resource... resource) {
-
-            mAsyncTaskDao.updateResource(resource[0]);
-            return null;
-
-
-        }
-    }
 }
-
-

--- a/app/src/main/java/com/tiptopgoodstudio/androidresources/db/dao/ResourceDao.java
+++ b/app/src/main/java/com/tiptopgoodstudio/androidresources/db/dao/ResourceDao.java
@@ -1,6 +1,12 @@
 package com.tiptopgoodstudio.androidresources.db.dao;
 
+/*
+ * Dao (Data access object) is an interface that defines the database interactions
+ * relating to the resource_table Room db table.
+ **/
+
 import android.arch.lifecycle.LiveData;
+import android.arch.lifecycle.MutableLiveData;
 import android.arch.persistence.room.Dao;
 import android.arch.persistence.room.Delete;
 import android.arch.persistence.room.Insert;
@@ -18,36 +24,76 @@ import static android.arch.persistence.room.OnConflictStrategy.REPLACE;
 public interface ResourceDao {
 
     /**
-     * Dao (Data access object) is an interface that define the database interactions.
-     * Room will generate an implementation during the run time.
-     **/
+     * insert single Reseource object into resource_table
+     *
+     * @param resource
+     */
     @Insert(onConflict = IGNORE)
     void insertResource(Resource resource);
 
+    /**
+     * insert multiple Resource objects into resource_table
+     *
+     * @param resources
+     */
     @Insert(onConflict = IGNORE)
     void insertResources(Resource... resources);
 
-
+    /**
+     * query db for all resourcce records from resource_table
+     *
+     * @return all resource records in LiveData wrapper
+     */
     @Query("SELECT * FROM resource_table")
     LiveData<List<Resource>> getResources();
 
+    /**
+     * query db for all resource records wihich match topic parameter from resource_table
+     *
+     * @param topic
+     * @return all resource records wihich match topic parameter
+     */
     @Query("SELECT * FROM resource_table WHERE resourceTopic LIKE :topic")
-    LiveData<List<Resource>> getTopicResources(String topic);
+    MutableLiveData<List<Resource>> getTopicResources(String topic);
 
+    /**
+     * query resource_table for all resource record which matches resourceId
+     *
+     * @param id
+     * @return Resource
+     */
     @Query("SELECT * FROM resource_table WHERE resourceId= :id")
     Resource getResourceById(int id);
 
+    /**
+     * query resource_table for resource record which matches resourceId
+     *
+     * @param id
+     * @return String resource format to which the resource refers
+     */
+    @Query("SELECT resourceFormat FROM resource_table WHERE resourceId=:id ")
+    String getResourceFormat(int id);
 
+    /**
+     * replace existing resource record in resource_table with new data
+     *
+     * @param resource
+     */
     @Update(onConflict = REPLACE)
     void updateResource(Resource resource);
 
+    /**
+     * delete all records from db resource_table
+     */
     @Query("DELETE FROM resource_table")
     void deleteAll();
 
+    /**
+     * delete single resource
+     *
+     * @param resource
+     */
     @Delete
     void delete(Resource resource);
-
-    @Query("SELECT resourceFormat FROM resource_table WHERE resourceId=:id ")
-    String getResourceFormat(int id);
 
 }


### PR DESCRIPTION
UI component which displays records filtered by topic requires a MutableLiveData<> wrapper instead of a LiveData<> wrapper. Change ResourceDao to return proper type.
ResourceRepository must expose functionality (described above), so create public method.
Repository currently accommodates insertion of only one Resource entity at a time. Modify to allow multiple entity insertions at a time.
Add deleteAll functionality as private method

Fixes #57  .
