### PR TITLE
Fixes #91: Make MainActivity launchMode as singleTop

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".ui.MainActivity">
+        <activity android:name=".ui.MainActivity"
+                    android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
Fixes #91 .

Changes proposed in this pull request:
Making MainActivity launchMode as singleTop prevents the FIrebase data from being downloaded everytime we navigate to MainActivity

