### PR TITLE
Fixes #95: Changed to FrameLayout to show error message when necessary

### DIFF
--- a/app/src/main/res/layout/resources_list.xml
+++ b/app/src/main/res/layout/resources_list.xml
@@ -13,12 +13,10 @@
   Converting it back to resources_list.xml for version 1 on 04/19/2018 by Divya
  -->
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_marginBottom="56dp"
-    android:background="@color/list_background_color"
-    android:orientation="vertical">
+    android:background="@color/list_background_color">
 
     <android.support.v7.widget.RecyclerView
         android:id="@+id/rv_resource_item"
@@ -27,10 +25,11 @@
 
     <TextView
         android:id="@+id/tv_error_message_display"
-        style="@style/TextAppearance.Compat.Notification.Info"
+        style="@style/TextAppearance.AppCompat.Title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:padding="@dimen/padding"
+        android:layout_gravity="center"
         android:text="@string/error_message"
         android:visibility="invisible" />
 
@@ -41,4 +40,4 @@
         android:layout_gravity="center"
         android:visibility="invisible" />
 
-</LinearLayout>
+</FrameLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,10 +7,10 @@
     <color name="colorMenuItem">#FFFFFF</color>
 
     <!-- Colors used in resource_item.xml (Added by Divya on 3/3/2018) -->
-    <color name="row_background_color">#FFFFFFFF</color>
+    <color name="row_background_color">#FFFFFF</color>
 
     <!-- Colors used in resource_item.xml (Added by Divya on 3/3/2018) -->
-    <color name="list_background_color">#FF555555</color>
+    <color name="list_background_color">#AAAAAA</color>
 
     <!-- Strings used in MainActivity (Added by Olga on 3/20/2018) -->
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -21,7 +21,7 @@
     <dimen name="stickyMargin">16dp</dimen>
 
     <!-- Dimensions used in resource_item.xml -->
-    <dimen name="row_margin_bottom">2dp</dimen>
+    <dimen name="row_margin_bottom">1dp</dimen>
 
     <dimen name="resource_icon_image_size">60dp</dimen>
     <dimen name="resource_icon_margin_right">20dp</dimen>


### PR DESCRIPTION
Fixes #95 .

Changes performed in this pull request:
Now error message is displayed when necessary in the Frame Layout. It was hidden in the previous LinearLayout
