### PR TITLE
Fixes: #133: Removed second activity launch from onResume

### DIFF
--- a/app/src/main/java/com/tiptopgoodstudio/androidresources/ui/LaunchActivity.java
+++ b/app/src/main/java/com/tiptopgoodstudio/androidresources/ui/LaunchActivity.java
@@ -94,21 +94,8 @@ public class LaunchActivity extends AppCompatActivity {
         }
     }
 
-    /*
-    * Added on 04/23/2018 by Olga Agafonova
-    * The user may have (re)connected to Wifi/Mobile while the app was paused:
-    * therefore, we need to check for connectivity again
-    * */
-    @Override
-    public void onResume(){
-       super.onResume();
-
-       checkConnectivityAndLoadResources();
-    }
-
     private void startMainActivity() {
         Intent intent = new Intent(this, MainActivity.class);
-        intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
         startActivity(intent);
     }
 }


### PR DESCRIPTION
Fixes #133  .

Changes proposed in this pull request:
Removed the second activity launch from onResume(). Although it seemed like a valid solution for network interruptions, it resulted in launching the activity twice. For network interruptions, the app will not automatically try to reconnect. Instead the user will have to relaunch the app when he/she is back on the network.

