### PR TITLE
Ensure text within sticky note boundary

### DIFF
--- a/app/src/main/res/layout/custom_view.xml
+++ b/app/src/main/res/layout/custom_view.xml
@@ -34,10 +34,11 @@
 
             <TextView
                 android:id="@+id/stickyNoteText"
-                android:layout_height="@dimen/stickyNoteHeight"
-                android:layout_width="@dimen/stickyNoteWidth"
+                android:layout_height="@dimen/stickyTextHeight"
+                android:layout_width="@dimen/stickyTextWidth"
                 android:gravity="center"
                 android:layout_centerHorizontal="true"
+                android:layout_marginTop="@dimen/stickyMargin"
                 android:textAppearance="@style/TextAppearance.AppCompat.Medium"
                 android:textColor="@color/stickyNoteTextColor"/>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -19,6 +19,9 @@
     <dimen name="stickyNoteWidth">300dp</dimen>
     <dimen name="stickyNoteHeight">300dp</dimen>
 
+    <dimen name="stickyTextWidth">140dp</dimen>
+    <dimen name="stickyTextHeight">140dp</dimen>
+
     <dimen name="stickyMargin">16dp</dimen>
 
     <!-- Dimensions used in resource_item.xml -->


### PR DESCRIPTION
Fixes #139  .

Changes proposed in this pull request:
Changed the dimensions of the TextView to overlap with the sticky note

